### PR TITLE
restore header hooks to unused state upon container destruction

### DIFF
--- a/include/boost/intrusive/bstree.hpp
+++ b/include/boost/intrusive/bstree.hpp
@@ -526,6 +526,7 @@ struct bstbase
             ( this->header_ptr()
             , detail::node_disposer<detail::null_disposer, value_traits, AlgoType>
                (detail::null_disposer(), &this->get_value_traits()));
+         node_algorithms::init(this->header_ptr());
       }
    }
 };

--- a/include/boost/intrusive/list.hpp
+++ b/include/boost/intrusive/list.hpp
@@ -205,6 +205,7 @@ class list_impl
    {
       if(is_safe_autounlink<ValueTraits::link_mode>::value){
          this->clear();
+         node_algorithms::init(this->get_root_node());
       }
    }
 

--- a/include/boost/intrusive/slist.hpp
+++ b/include/boost/intrusive/slist.hpp
@@ -339,6 +339,7 @@ class slist_impl
    {
       if(is_safe_autounlink<ValueTraits::link_mode>::value){
          this->clear();
+         node_algorithms::init(this->get_root_node());
       }
    }
 


### PR DESCRIPTION
Feature request: https://svn.boost.org/trac/boost/ticket/9949
