### PR TITLE
[winrt support] Not defining BOOST_INTRUSIVE_TT_TEST_MSC_FUNC_SIGS if targeting ARM on Windows

### DIFF
--- a/include/boost/intrusive/detail/mpl.hpp
+++ b/include/boost/intrusive/detail/mpl.hpp
@@ -1,9 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 //
 // (C) Copyright Ion Gaztanaga  2006-2013
-// Copyright Steve Gates 2013.  
-// Copyright George Mileka 2013.  
-// Portions Copyright (c) Microsoft Open Technologies, Inc. 
+// Copyright (c) Microsoft Corporation
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
Making sure BOOST_INTRUSIVE_TT_TEST_MSC_FUNC_SIGS is not defined if the macro _M_ARM is defined.

This is part of the work mentioned on the Boost dev mailing list:

http://boost.2283326.n4.nabble.com/winrt-support-Adding-support-for-Windows-8-store-phone-to-Boost-libraries-tc4661713.html
