### PR TITLE
N3644 "Null Forward Iterator" compliance

### DIFF
--- a/include/boost/intrusive/detail/utilities.hpp
+++ b/include/boost/intrusive/detail/utilities.hpp
@@ -1223,6 +1223,7 @@ struct iiterator_members
 {
 
    iiterator_members()
+      :  nodeptr_(), ptr_()
    {}
 
    iiterator_members(const NodePtr &n_ptr, const StoredPointer &data)
@@ -1240,6 +1241,7 @@ template<class NodePtr, class StoredPointer>
 struct iiterator_members<NodePtr, StoredPointer, false>
 {
    iiterator_members()
+      :  nodeptr_()
    {}
 
    iiterator_members(const NodePtr &n_ptr, const StoredPointer &)


### PR DESCRIPTION
Updated the iiterator_members class for compliance with n3644.
See commit on Boost.Container.

More changes might be needed if all intrusive containers are to comply to n3644.
