### PR TITLE
ebo_functor_holder: compile fix for copy constructor

### DIFF
--- a/include/boost/intrusive/detail/ebo_functor_holder.hpp
+++ b/include/boost/intrusive/detail/ebo_functor_holder.hpp
@@ -183,7 +183,7 @@ class ebo_functor_holder
    {}
 
    ebo_functor_holder(const ebo_functor_holder &x)
-      : t_(x)
+      : t_(x.t_)
    {}
 
    ebo_functor_holder(BOOST_RV_REF(ebo_functor_holder) x)


### PR DESCRIPTION
boost-1.60 doesn't compile my application due to this small error