### PR TITLE
[CMake] Add minimal cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright 2019 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.Intrusive is currently experimental at best
+#       and the interface is likely to change in the future
+
+cmake_minimum_required( VERSION 3.5 )
+
+project( Boost.Intrusive LANGUAGES CXX )
+
+add_library (boost_intrusive INTERFACE )
+add_library( Boost::intrusive ALIAS boost_intrusive )
+
+target_include_directories( boost_intrusive INTERFACE include )
+
+target_link_libraries( boost_intrusive
+    INTERFACE
+        Boost::assert
+        Boost::config
+        Boost::container_hash
+        Boost::core
+        Boost::move
+        Boost::static_assert
+)


### PR DESCRIPTION
This cmake file just provides the minimal infrastructure necessary, such that other libraries can get a sensible result from calling


    add_subdirectory( <path-to-boost_intrusive> )
    target_link_libraries( <my_lib> PUBLIC Boost::intrusive )


provided that all direct and indirect dependencies are also being added via `add_subdirectory` (which can e.g happen via globbing expression).

More information:

    * https://groups.google.com/forum/#!topic/boost-developers-archive/9ZdrVbAn1aU


Of course the file can be extended to e.g. build and run tests and support installation, but that is out of scope for this particular PR.

Please note that this is largely orthogonal to the recent addition to b2/boost by peter dimov, which is concerned with providing cmake config files for "classic" boost installations via b2.