### PR TITLE
Fix tests with BOOST_INTRUSIVE_VARIADIC_TEMPLATES enabled

### DIFF
--- a/include/boost/intrusive/pack_options.hpp
+++ b/include/boost/intrusive/pack_options.hpp
@@ -209,6 +209,12 @@ struct do_pack<typelist<Prev, Last> >
    typedef typename Prev::template pack<Last> type;
 };
 
+template<class ...Others>
+struct do_pack<typelist<void, Others...> >
+{
+   typedef typename do_pack<typelist<Others...> >::type type;
+};
+
 template<class Prev, class ...Others>
 struct do_pack<typelist<Prev, Others...> >
 {


### PR DESCRIPTION
Allow void as an option with `BOOST_INTRUSIVE_VARIADIC_TEMPLATES` enabled - this matches the behaviour with it disabled. The tests have recently started to depend on being able to pass void as an option with no effect.

@igaztanaga, why is `BOOST_INTRUSIVE_VARIADIC_TEMPLATES` disabled by default? Looking at the history, it was enabled way back in 2011 and was removed in a seemingly unrelated change (8a53a5af)