### PR TITLE
MSVC "assignment within conditional" warning fix

### DIFF
--- a/include/boost/intrusive/bstree_algorithms.hpp
+++ b/include/boost/intrusive/bstree_algorithms.hpp
@@ -1014,7 +1014,8 @@ class bstree_algorithms : public bstree_algorithms_base<NodeTraits>
       while(x){
          ++depth;
          y = x;
-         x = (left_child = comp(key, x)) ?
+         left_child = comp(key, x);
+         x = left_child ?
                NodeTraits::get_left(x) : (prev = y, NodeTraits::get_right(x));
       }
 


### PR DESCRIPTION
The latest MSVC 2019 issues a warning on this line. This change performs the assignment prior to the conditional.