### PR TITLE
Add missing include

### DIFF
--- a/include/boost/intrusive/detail/simple_disposers.hpp
+++ b/include/boost/intrusive/detail/simple_disposers.hpp
@@ -13,6 +13,8 @@
 #ifndef BOOST_INTRUSIVE_DETAIL_SIMPLE_DISPOSERS_HPP
 #define BOOST_INTRUSIVE_DETAIL_SIMPLE_DISPOSERS_HPP
 
+#include <boost/intrusive/detail/workaround.hpp>
+
 #ifndef BOOST_CONFIG_HPP
 #  include <boost/config.hpp>
 #endif


### PR DESCRIPTION
This patch makes the header able to be built standalone, making possible C++ clang modules builds.@vgvassilev