### PR TITLE
UB: comparing unrelated pointers

### DIFF
--- a/include/boost/intrusive/hashtable.hpp
+++ b/include/boost/intrusive/hashtable.hpp
@@ -932,7 +932,8 @@ struct bucket_plus_vtraits
 
       //The end node is embedded in the singly linked list:
       //iterate until we reach it.
-      while(!(first_ptr <= it.pointed_node() && it.pointed_node() <= last_ptr)){
+      while(!(std::less_equal<slist_node_ptr>()(first_ptr, it.pointed_node()) &&
+              std::less_equal<slist_node_ptr>()(it.pointed_node(), last_ptr))){
          ++it;
       }
       //Now get the bucket_impl from the iterator


### PR DESCRIPTION
detected by gcc10 asan (-fsanitize=pointer-compare):

==13==ERROR: AddressSanitizer: invalid-pointer-pair: 0x612000031cc8 0x61d0000000d0
    #0 0x18f3270 in boost::intrusive::bucket_plus_vtraits<...>::priv_get_bucket_num_no_hash_store(boost::intrusive::slist_iterator<boost::intrusive::trivial_value_traits<boost::intrusive::slist_node_traits<void*>, (boost::intrusive::link_mode_type)0>, false>, boost::move_detail::bool_<false>) libs/intrusive/include/boost/intrusive/hashtable.hpp:935
    #1 0x18f3270 in boost::intrusive::hashtable_impl<...>::priv_get_bucket_num_hash_dispatch(boost::intrusive::slist_iterator<boost::intrusive::trivial_value_traits<boost::intrusive::slist_node_traits<void*>, (boost::intrusive::link_mode_type)0>, false>, boost::move_detail::bool_<false>) libs/intrusive/include/boost/intrusive/hashtable.hpp:3509
    #2 0x18f3270 in boost::intrusive::hashtable_impl<...>::priv_get_bucket_num(boost::intrusive::slist_iterator<boost::intrusive::trivial_value_traits<boost::intrusive::slist_node_traits<void*>, (boost::intrusive::link_mode_type)0>, false>) /home/edward.catmur/packages/boost/1.75.0-maven6/libs/intrusive/include/boost/intrusive/hashtable.hpp:3500
    #3 0x18f3270 in boost::move_detail::disable_if_convertible<...>::type boost::intrusive::hashtable_impl<...>::erase_and_dispose<...>(...) libs/intrusive/include/boost/intrusive/hashtable.hpp:2360