### PR TITLE
list_iterator: Fix declaration of node shadowing member

### DIFF
--- a/include/boost/intrusive/detail/list_iterator.hpp
+++ b/include/boost/intrusive/detail/list_iterator.hpp
@@ -81,8 +81,8 @@ class list_iterator
    BOOST_INTRUSIVE_FORCEINLINE node_ptr pointed_node() const
    { return members_.nodeptr_; }
 
-   BOOST_INTRUSIVE_FORCEINLINE list_iterator &operator=(const node_ptr &node)
-   {  members_.nodeptr_ = node;  return *this;  }
+   BOOST_INTRUSIVE_FORCEINLINE list_iterator &operator=(const node_ptr &nodeptr)
+   {  members_.nodeptr_ = nodeptr;  return *this;  }
 
    BOOST_INTRUSIVE_FORCEINLINE const_value_traits_ptr get_value_traits() const
    {  return members_.get_ptr(); }


### PR DESCRIPTION
When code is compiled with -Wshadow (outside GCC's "system" include
paths), the compiler will complain:

```
warning: declaration of ‘node’ shadows a member of ‘boost::intrusive::list_iterator<ValueTraits, IsConst>’
```

Example test:

```
g++ doc_list.cpp -o doc_list -I../include -Wshadow -Wall -Wextra -Werror
```
