### PR TITLE
list: fix `remove` / `remove_and_dispose`

### DIFF
--- a/include/boost/intrusive/list.hpp
+++ b/include/boost/intrusive/list.hpp
@@ -1117,7 +1117,7 @@ class list_impl
    //! <b>Note</b>: The relative order of elements that are not removed is unchanged,
    //!   and iterators to elements that are not removed remain valid.
    void remove(const_reference value) BOOST_NOEXCEPT
-   {  this->remove_if(value_equal<const_reference>(value));  }
+   {  this->remove_if(detail::equal_to_value<const_reference>(value));  }
 
    //! <b>Requires</b>: Disposer::operator()(pointer) shouldn't throw.
    //!
@@ -1132,7 +1132,7 @@ class list_impl
    //!   and iterators to elements that are not removed remain valid.
    template<class Disposer>
    void remove_and_dispose(const_reference value, Disposer disposer) BOOST_NOEXCEPT
-   {  this->remove_and_dispose_if(value_equal<const_reference>(value), disposer);  }
+   {  this->remove_and_dispose_if(detail::equal_to_value<const_reference>(value), disposer);  }
 
    //! <b>Effects</b>: Removes all the elements for which a specified
    //!   predicate is satisfied. No destructors are called.


### PR DESCRIPTION
`value_equal` is a simple wrapper to `operator==`, but does not bind the
argument to a predicate