### PR TITLE
update actions/checkout in GitHub Actions to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install packages
         if: matrix.install
@@ -167,7 +167,7 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Boost
         shell: cmd


### PR DESCRIPTION
Updates the `actions/checkout` actions used in the GitHub Actions workflow to its newest version.

Changes in [actions/checkout](https://github.com/actions/checkout):

> ## v3.0.2
> - [Add input `set-safe-directory`](https://github.com/actions/checkout/pull/770)
>
> ## v3.0.1
> - [Fixed an issue where checkout failed to run in container jobs due to the new git setting `safe.directory`](https://github.com/actions/checkout/pull/762)
> - [Bumped various npm package versions](https://github.com/actions/checkout/pull/744)
>
> ## v3.0.0
>
> - [Update to node 16](https://github.com/actions/checkout/pull/689)

As far as I can tell this should be backwards compatible, so I do not expect any breakage.