### PR TITLE
Suppress unused variable warnings on node_count (clang 15)

### DIFF
--- a/include/boost/intrusive/list.hpp
+++ b/include/boost/intrusive/list.hpp
@@ -36,6 +36,7 @@
 #include <boost/intrusive/detail/size_holder.hpp>
 #include <boost/intrusive/detail/algorithm.hpp>
 
+#include <boost/core/ignore_unused.hpp>
 #include <boost/move/utility_core.hpp>
 #include <boost/static_assert.hpp>
 
@@ -1349,6 +1350,7 @@ class list_impl
          return;
       }
       size_t node_count = 0;
+      boost::ignore_unused(node_count);
       const_node_ptr p = header_ptr;
       while (true)
       {

--- a/include/boost/intrusive/slist.hpp
+++ b/include/boost/intrusive/slist.hpp
@@ -40,6 +40,7 @@
 #include <boost/intrusive/detail/value_functors.hpp>
 #include <boost/intrusive/detail/node_cloner_disposer.hpp>
 
+#include <boost/core/ignore_unused.hpp>
 #include <boost/move/utility_core.hpp>
 #include <boost/static_assert.hpp>
 
@@ -1937,6 +1938,7 @@ class slist_impl
          return;
       }
       size_t node_count = 0;
+      boost::ignore_unused(node_count);
       const_node_ptr p = header_ptr;
       while (true)
       {


### PR DESCRIPTION
Clang 15 is smart enough to realize that node_count is incremented but never read (if constant_time_size is false or asserts are disabled).

Use boost::ignore_unused to suppress the warning.