### PR TITLE
Simplify ebo_function_holder

### DIFF
--- a/include/boost/intrusive/avltree.hpp
+++ b/include/boost/intrusive/avltree.hpp
@@ -22,7 +22,6 @@
 #include <boost/intrusive/detail/avltree_node.hpp>
 #include <boost/intrusive/bstree.hpp>
 #include <boost/intrusive/detail/tree_node.hpp>
-#include <boost/intrusive/detail/ebo_functor_holder.hpp>
 #include <boost/intrusive/detail/mpl.hpp>
 #include <boost/intrusive/pointer_traits.hpp>
 #include <boost/intrusive/detail/get_value_traits.hpp>

--- a/include/boost/intrusive/detail/ebo_functor_holder.hpp
+++ b/include/boost/intrusive/detail/ebo_functor_holder.hpp
@@ -29,310 +29,8 @@ namespace boost {
 namespace intrusive {
 namespace detail {
 
-#if defined(BOOST_MSVC) || defined(__BORLANDC_)
-#define BOOST_INTRUSIVE_TT_DECL __cdecl
-#else
-#define BOOST_INTRUSIVE_TT_DECL
-#endif
-
-#if defined(_MSC_EXTENSIONS) && !defined(__BORLAND__) && !defined(_WIN64) && !defined(_M_ARM) && !defined(_M_ARM64) && !defined(UNDER_CE)
-#define BOOST_INTRUSIVE_TT_TEST_MSC_FUNC_SIGS
-#endif
-
-template <typename T>
-struct is_unary_or_binary_function_impl
-{  static const bool value = false; };
-
-// see boost ticket #4094
-// avoid duplicate definitions of is_unary_or_binary_function_impl
-#ifndef BOOST_INTRUSIVE_TT_TEST_MSC_FUNC_SIGS
-
-template <typename R>
-struct is_unary_or_binary_function_impl<R (*)()>
-{  static const bool value = true;  };
-
-template <typename R>
-struct is_unary_or_binary_function_impl<R (*)(...)>
-{  static const bool value = true;  };
-
-#if 201703L <= BOOST_CXX_VERSION && !defined(BOOST_NO_CXX11_NOEXCEPT)
-
-template <typename R>
-struct is_unary_or_binary_function_impl<R (*)() noexcept>
-{  static const bool value = true; };
-
-template <typename R>
-struct is_unary_or_binary_function_impl<R (*)(...) noexcept>
-{  static const bool value = true; };
-
-#endif
-
-#else // BOOST_INTRUSIVE_TT_TEST_MSC_FUNC_SIGS
-
-template <typename R>
-struct is_unary_or_binary_function_impl<R (__stdcall*)()>
-{  static const bool value = true;  };
-
-#ifndef _MANAGED
-
-template <typename R>
-struct is_unary_or_binary_function_impl<R (__fastcall*)()>
-{  static const bool value = true;  };
-
-#endif
-
-template <typename R>
-struct is_unary_or_binary_function_impl<R (__cdecl*)()>
-{  static const bool value = true;  };
-
-template <typename R>
-struct is_unary_or_binary_function_impl<R (__cdecl*)(...)>
-{  static const bool value = true;  };
-
-#if 201703L <= BOOST_CXX_VERSION && !defined(BOOST_NO_CXX11_NOEXCEPT)
-
-template <typename R>
-struct is_unary_or_binary_function_impl<R (__stdcall*)() noexcept>
-{  static const bool value = true; };
-
-#ifndef _MANAGED
-
-template <typename R>
-struct is_unary_or_binary_function_impl<R (__fastcall*)() noexcept>
-{  static const bool value = true; };
-
-#endif
-
-template <typename R>
-struct is_unary_or_binary_function_impl<R (__cdecl*)() noexcept>
-{  static const bool value = true; };
-
-template <typename R>
-struct is_unary_or_binary_function_impl<R (__cdecl*)(...) noexcept>
-{  static const bool value = true; };
-
-#endif
-
-#endif
-
-// see boost ticket #4094
-// avoid duplicate definitions of is_unary_or_binary_function_impl
-#ifndef BOOST_INTRUSIVE_TT_TEST_MSC_FUNC_SIGS
-
-template <typename R, class T0>
-struct is_unary_or_binary_function_impl<R (*)(T0)>
-{  static const bool value = true;  };
-
-template <typename R, class T0>
-struct is_unary_or_binary_function_impl<R (*)(T0, ...)>
-{  static const bool value = true;  };
-
-#if 201703L <= BOOST_CXX_VERSION && !defined(BOOST_NO_CXX11_NOEXCEPT)
-
-template <typename R, class T0>
-struct is_unary_or_binary_function_impl<R (*)(T0) noexcept>
-{  static const bool value = true; };
-
-template <typename R, class T0>
-struct is_unary_or_binary_function_impl<R (*)(T0, ...) noexcept>
-{  static const bool value = true; };
-
-#endif
-
-#else // BOOST_INTRUSIVE_TT_TEST_MSC_FUNC_SIGS
-
-template <typename R, class T0>
-struct is_unary_or_binary_function_impl<R (__stdcall*)(T0)>
-{  static const bool value = true;  };
-
-#ifndef _MANAGED
-
-template <typename R, class T0>
-struct is_unary_or_binary_function_impl<R (__fastcall*)(T0)>
-{  static const bool value = true;  };
-
-#endif
-
-template <typename R, class T0>
-struct is_unary_or_binary_function_impl<R (__cdecl*)(T0)>
-{  static const bool value = true;  };
-
-template <typename R, class T0>
-struct is_unary_or_binary_function_impl<R (__cdecl*)(T0, ...)>
-{  static const bool value = true;  };
-
-#if 201703L <= BOOST_CXX_VERSION && !defined(BOOST_NO_CXX11_NOEXCEPT)
-
-template <typename R, class T0>
-struct is_unary_or_binary_function_impl<R (__stdcall*)(T0) noexcept>
-{  static const bool value = true; };
-
-#ifndef _MANAGED
-
-template <typename R, class T0>
-struct is_unary_or_binary_function_impl<R (__fastcall*)(T0) noexcept>
-{  static const bool value = true; };
-
-#endif
-
-template <typename R, class T0>
-struct is_unary_or_binary_function_impl<R (__cdecl*)(T0) noexcept>
-{  static const bool value = true; };
-
-template <typename R, class T0>
-struct is_unary_or_binary_function_impl<R (__cdecl*)(T0, ...) noexcept>
-{  static const bool value = true; };
-
-#endif
-
-#endif
-
-// see boost ticket #4094
-// avoid duplicate definitions of is_unary_or_binary_function_impl
-#ifndef BOOST_INTRUSIVE_TT_TEST_MSC_FUNC_SIGS
-
-template <typename R, class T0, class T1>
-struct is_unary_or_binary_function_impl<R (*)(T0, T1)>
-{  static const bool value = true;  };
-
-template <typename R, class T0, class T1>
-struct is_unary_or_binary_function_impl<R (*)(T0, T1, ...)>
-{  static const bool value = true;  };
-
-#if 201703L <= BOOST_CXX_VERSION && !defined(BOOST_NO_CXX11_NOEXCEPT)
-
-template <typename R, class T0, class T1>
-struct is_unary_or_binary_function_impl<R (*)(T0, T1) noexcept>
-{  static const bool value = true; };
-
-template <typename R, class T0, class T1>
-struct is_unary_or_binary_function_impl<R (*)(T0, T1, ...) noexcept>
-{  static const bool value = true; };
-
-#endif
-
-#else // BOOST_INTRUSIVE_TT_TEST_MSC_FUNC_SIGS
-
-template <typename R, class T0, class T1>
-struct is_unary_or_binary_function_impl<R (__stdcall*)(T0, T1)>
-{  static const bool value = true;  };
-
-#ifndef _MANAGED
-
-template <typename R, class T0, class T1>
-struct is_unary_or_binary_function_impl<R (__fastcall*)(T0, T1)>
-{  static const bool value = true;  };
-
-#endif
-
-template <typename R, class T0, class T1>
-struct is_unary_or_binary_function_impl<R (__cdecl*)(T0, T1)>
-{  static const bool value = true;  };
-
-template <typename R, class T0, class T1>
-struct is_unary_or_binary_function_impl<R (__cdecl*)(T0, T1, ...)>
-{  static const bool value = true;  };
-
-#if 201703L <= BOOST_CXX_VERSION && !defined(BOOST_NO_CXX11_NOEXCEPT)
-
-template <typename R, class T0, class T1>
-struct is_unary_or_binary_function_impl<R (__stdcall*)(T0, T1) noexcept>
-{  static const bool value = true; };
-
-#ifndef _MANAGED
-
-template <typename R, class T0, class T1>
-struct is_unary_or_binary_function_impl<R (__fastcall*)(T0, T1) noexcept>
-{  static const bool value = true; };
-
-#endif
-
-template <typename R, class T0, class T1>
-struct is_unary_or_binary_function_impl<R (__cdecl*)(T0, T1) noexcept>
-{  static const bool value = true; };
-
-template <typename R, class T0, class T1>
-struct is_unary_or_binary_function_impl<R (__cdecl*)(T0, T1, ...) noexcept>
-{  static const bool value = true; };
-
-#endif
-
-#endif
-
-template <typename T>
-struct is_unary_or_binary_function_impl<T&>
-{  static const bool value = false; };
-
-template<typename T>
-struct is_unary_or_binary_function : is_unary_or_binary_function_impl<T>
-{};
-
-template<typename T, typename Tag = void, bool = is_unary_or_binary_function<T>::value>
+template<typename T, typename Tag = void>
 class ebo_functor_holder
-{
-   BOOST_COPYABLE_AND_MOVABLE(ebo_functor_holder)
-
-   public:
-   typedef T functor_type;
-
-   inline ebo_functor_holder()
-      : t_()
-   {}
-
-   inline explicit ebo_functor_holder(const T &t)
-      : t_(t)
-   {}
-
-   inline explicit ebo_functor_holder(BOOST_RV_REF(T) t)
-      : t_(::boost::move(t))
-   {}
-
-   template<class Arg1, class Arg2>
-   inline ebo_functor_holder(BOOST_FWD_REF(Arg1) arg1, BOOST_FWD_REF(Arg2) arg2)
-      : t_(::boost::forward<Arg1>(arg1), ::boost::forward<Arg2>(arg2))
-   {}
-
-   inline ebo_functor_holder(const ebo_functor_holder &x)
-      : t_(x.t_)
-   {}
-
-   inline ebo_functor_holder(BOOST_RV_REF(ebo_functor_holder) x)
-      : t_(x.t_)
-   {}
-
-   inline ebo_functor_holder& operator=(BOOST_COPY_ASSIGN_REF(ebo_functor_holder) x)
-   {
-      this->get() = x.get();
-      return *this;
-   }
-
-   inline ebo_functor_holder& operator=(BOOST_RV_REF(ebo_functor_holder) x)
-   {
-      this->get() = ::boost::move(x.get());
-      return *this;
-   }
-
-   inline ebo_functor_holder& operator=(const T &x)
-   {
-      this->get() = x;
-      return *this;
-   }
-
-   inline ebo_functor_holder& operator=(BOOST_RV_REF(T) x)
-   {
-      this->get() = ::boost::move(x);
-      return *this;
-   }
-
-   inline T&       get(){return t_;}
-   inline const T& get()const{return t_;}
-
-   private:
-   T t_;
-};
-
-template<typename T, typename Tag>
-class ebo_functor_holder<T, Tag, false>
    :  public T
 {
    BOOST_COPYABLE_AND_MOVABLE(ebo_functor_holder)
@@ -378,20 +76,69 @@ class ebo_functor_holder<T, Tag, false>
       return *this;
    }
 
-   inline ebo_functor_holder& operator=(const T &x)
+   inline ebo_functor_holder& operator=(const T &t)
    {
-      this->get() = x;
+      this->get() = t;
       return *this;
    }
 
-   inline ebo_functor_holder& operator=(BOOST_RV_REF(T) x)
+   inline ebo_functor_holder& operator=(BOOST_RV_REF(T) t)
    {
-      this->get() = ::boost::move(x);
+      this->get() = ::boost::move(t);
       return *this;
    }
 
    inline T&       get(){return *this;}
    inline const T& get()const{return *this;}
+};
+
+template<typename T, typename Tag>
+class ebo_functor_holder<T *, Tag>
+{
+   BOOST_COPYABLE_AND_MOVABLE(ebo_functor_holder)
+
+   public:
+   typedef T functor_type;
+
+   inline ebo_functor_holder()
+      : t_()
+   {}
+
+   inline explicit ebo_functor_holder(T * t)
+      : t_(t)
+   {}
+
+   inline ebo_functor_holder(const ebo_functor_holder &x)
+      : t_(x.t_)
+   {}
+
+   inline ebo_functor_holder(BOOST_RV_REF(ebo_functor_holder) x)
+      : t_(x.t_)
+   {}
+
+   inline ebo_functor_holder& operator=(BOOST_COPY_ASSIGN_REF(ebo_functor_holder) x)
+   {
+      this->t_ = x.t_;
+      return *this;
+   }
+
+   inline ebo_functor_holder& operator=(BOOST_RV_REF(ebo_functor_holder) x)
+   {
+      this->t_ = ::boost::move(x.t_);
+      return *this;
+   }
+
+   inline ebo_functor_holder& operator=(T * t)
+   {
+      this->t_ = t;
+      return *this;
+   }
+
+   inline T&       get(){return *t_;}
+   inline const T& get()const{return *t_;}
+
+   private:
+   T * t_;
 };
 
 }  //namespace detail {

--- a/include/boost/intrusive/detail/key_nodeptr_comp.hpp
+++ b/include/boost/intrusive/detail/key_nodeptr_comp.hpp
@@ -22,7 +22,6 @@
 #endif
 
 #include <boost/intrusive/detail/mpl.hpp>
-#include <boost/intrusive/detail/ebo_functor_holder.hpp>
 #include <boost/intrusive/detail/tree_value_compare.hpp>
 
 


### PR DESCRIPTION
Upon further inspection i've noticed that implementation of `ebo_function_holder` is extremely redundant. This class template has essentially two flavors:
- specialization for cases when `T` is a class type, inheriting from it, hopefully utilizing Empty Base Optimization
- specialization for cases when `T` is a pointer to function type, storing pointer as a field

Currently a fancy `is_unary_or_binary_function` trait is used to distinguish between these flavors, even though code only really cares whether it can inherit from `T` or not.

I've changed  `ebo_function_holder` to specialize for `T *` instead. This allowed to
- get rid of defaulted third template parameter of `ebo_function_holder` which was used to store trait evaluation result
- get rid of `is_unary_or_binary_function` and `is_unary_or_binary_function_impl` classes since they were otherwise unused

Additionally i've removed
- constructor taking two arguments from specialization dealing with function pointer. Given that `t_` is a pointer to function, initialization `: t_(::boost::forward<Arg1>(arg1), ::boost::forward<Arg2>(arg2))` couldn't possibly be valid. Presumably it was a result of copypasta.
- a couple of unused includes of `ebo_function_holder.hpp`

I believe these changes preserve backward compatibility, except for cases when library users directly wrote `detail::is_unary_or_binary_function` in their code which they probably shouldn't have since it was not a part of public API.